### PR TITLE
feat: bump periphery dependency to 1.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@aave/aave-token": "^1.0.4",
         "@aave/core-v3": "^1.17.0",
-        "@aave/periphery-v3": "^1.23.0",
+        "@aave/periphery-v3": "^1.23.1",
         "@aave/safety-module": "^1.0.3",
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
         "@nomicfoundation/hardhat-toolbox": "^2.0.0",
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@aave/periphery-v3": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@aave/periphery-v3/-/periphery-v3-1.23.0.tgz",
-      "integrity": "sha512-j2CFops1NYek/RWb4ElbQyE+X8LVsG67bSPMhmU37MZinRF1nTeZryjJUi2Axc3JPyUh27DCT7KRSAl2Tx2IFA==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@aave/periphery-v3/-/periphery-v3-1.23.1.tgz",
+      "integrity": "sha512-nazKiED6kbIMzUs3XTnhqlYObY9fCF3KO5ufeLHQ0IuUzDPL2i1cOqA5s30x6Ve98S0oXYgo9Mx4Nx+un9VV0w==",
       "dev": true,
       "dependencies": {
         "@aave/core-v3": "1.17.0"
@@ -11484,9 +11484,9 @@
       "dev": true
     },
     "@aave/periphery-v3": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@aave/periphery-v3/-/periphery-v3-1.23.0.tgz",
-      "integrity": "sha512-j2CFops1NYek/RWb4ElbQyE+X8LVsG67bSPMhmU37MZinRF1nTeZryjJUi2Axc3JPyUh27DCT7KRSAl2Tx2IFA==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@aave/periphery-v3/-/periphery-v3-1.23.1.tgz",
+      "integrity": "sha512-nazKiED6kbIMzUs3XTnhqlYObY9fCF3KO5ufeLHQ0IuUzDPL2i1cOqA5s30x6Ve98S0oXYgo9Mx4Nx+un9VV0w==",
       "dev": true,
       "requires": {
         "@aave/core-v3": "1.17.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@aave/aave-token": "^1.0.4",
     "@aave/core-v3": "^1.17.0",
-    "@aave/periphery-v3": "^1.23.0",
+    "@aave/periphery-v3": "^1.23.1",
     "@aave/safety-module": "^1.0.3",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",


### PR DESCRIPTION
- Bump @aave/periphery-v3 npm package to 1.23.1