### PR TITLE
feat: update @aave/core-v3@1.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@aave/aave-token": "^1.0.4",
-        "@aave/core-v3": "^1.17.0",
+        "@aave/core-v3": "^1.17.1",
         "@aave/periphery-v3": "^1.23.1",
         "@aave/safety-module": "^1.0.3",
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@aave/core-v3": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.0.tgz",
-      "integrity": "sha512-vcGEPcoDILN1ZBXeqRsK+TXp1VGDvYxaiq/ZJ2XT2/134PbmXAlNlZIrGw1b4WIwIG4egNu8OW6whyWjp/aLlA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.1.tgz",
+      "integrity": "sha512-OAHtclfz4LvHDF5Sh2RUfBtOHkEXe0r9xocrAv+3XSiH3hkSh/tzwxdiKGQimqFHR1fyULiVvuOjp6Q5yK4r8A==",
       "dev": true,
       "engines": {
         "node": ">=16.0.0"
@@ -76,6 +76,15 @@
       "dev": true,
       "dependencies": {
         "@aave/core-v3": "1.17.0"
+      }
+    },
+    "node_modules/@aave/periphery-v3/node_modules/@aave/core-v3": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.0.tgz",
+      "integrity": "sha512-vcGEPcoDILN1ZBXeqRsK+TXp1VGDvYxaiq/ZJ2XT2/134PbmXAlNlZIrGw1b4WIwIG4egNu8OW6whyWjp/aLlA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aave/safety-module": {
@@ -11478,9 +11487,9 @@
       }
     },
     "@aave/core-v3": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.0.tgz",
-      "integrity": "sha512-vcGEPcoDILN1ZBXeqRsK+TXp1VGDvYxaiq/ZJ2XT2/134PbmXAlNlZIrGw1b4WIwIG4egNu8OW6whyWjp/aLlA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.1.tgz",
+      "integrity": "sha512-OAHtclfz4LvHDF5Sh2RUfBtOHkEXe0r9xocrAv+3XSiH3hkSh/tzwxdiKGQimqFHR1fyULiVvuOjp6Q5yK4r8A==",
       "dev": true
     },
     "@aave/periphery-v3": {
@@ -11490,6 +11499,14 @@
       "dev": true,
       "requires": {
         "@aave/core-v3": "1.17.0"
+      },
+      "dependencies": {
+        "@aave/core-v3": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@aave/core-v3/-/core-v3-1.17.0.tgz",
+          "integrity": "sha512-vcGEPcoDILN1ZBXeqRsK+TXp1VGDvYxaiq/ZJ2XT2/134PbmXAlNlZIrGw1b4WIwIG4egNu8OW6whyWjp/aLlA==",
+          "dev": true
+        }
       }
     },
     "@aave/safety-module": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "dist/helpers/index.js",
   "devDependencies": {
     "@aave/aave-token": "^1.0.4",
-    "@aave/core-v3": "^1.17.0",
+    "@aave/core-v3": "^1.17.1",
     "@aave/periphery-v3": "^1.23.1",
     "@aave/safety-module": "^1.0.3",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",


### PR DESCRIPTION
- Updates the @aave/core-v3 package that contains the License fix for base tokenization contracts.

Link T-2968