### PR TITLE
Fixed typo that gives error while building

### DIFF
--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -14,7 +14,7 @@ export * from "./utilities/signer";
 export * from "../markets/aave/commons";
 export * from "../markets/aave/rateStrategies";
 export * from "../markets/aave/reservesConfigs";
-export * from "../tasks/market-registry/market-registry:add";
+export * from "../tasks/market-registry/market-registry_add";
 export * from "../tasks/misc/deploy-ui-helpers";
 export * from "../tasks/misc/deploy-UiIncentiveDataProvider";
 export * from "../tasks/misc/deploy-UiPoolDataProvider";


### PR DESCRIPTION
There seems to be a typing error in [helpers/index.ts](https://github.com/aave/aave-v3-deploy/blob/main/helpers/index.ts), line 17.

I believe the correct path is `"../tasks/market-registry/market-registry_add"` instead of `"../tasks/market-registry/market-registry:add"`. Changing this allowed me to continue with building.

The corresponding issue is #49.