### PR TITLE
chore: log reward tokens only if there is any deployment

### DIFF
--- a/deploy/02_market/00_testnet/00_token_setup.ts
+++ b/deploy/02_market/00_testnet/00_token_setup.ts
@@ -147,37 +147,40 @@ const func: DeployFunction = async function ({
       (1000 * 60 * 60).toString(),
     ]);
 
-    console.log("Testnet Reserve Tokens");
-    console.log("======================");
-
     const allDeployments = await deployments.all();
-    const testnetDeployment = Object.keys(allDeployments).filter((x) =>
-      x.includes(TESTNET_TOKEN_PREFIX)
-    );
-    testnetDeployment.forEach((key) =>
-      console.log(key, allDeployments[key].address)
-    );
-
-    console.log("Testnet Reward Tokens");
-    console.log("======================");
-
     const rewardDeployment = Object.keys(allDeployments).filter((x) =>
       x.includes(TESTNET_REWARD_TOKEN_PREFIX)
     );
 
-    rewardDeployment.forEach((key) =>
-      console.log(key, allDeployments[key].address)
-    );
-
-    console.log(
-      "Native Token Wrapper WETH9",
-      (
-        await deployments.get(
-          `${poolConfig.WrappedNativeTokenSymbol}${TESTNET_TOKEN_PREFIX}`
-        )
-      ).address
-    );
+    if (rewardDeployment.length > 0) {
+      console.log("Testnet Reward Tokens");
+      console.log("======================");
+      rewardDeployment.forEach((key) =>
+        console.log(key, allDeployments[key].address)
+      );
+    }
   }
+
+  console.log("Testnet Reserve Tokens");
+  console.log("======================");
+
+  const allDeployments = await deployments.all();
+  const testnetDeployment = Object.keys(allDeployments).filter((x) =>
+    x.includes(TESTNET_TOKEN_PREFIX)
+  );
+  testnetDeployment.forEach((key) =>
+    console.log(key, allDeployments[key].address)
+  );
+
+  console.log(
+    "Native Token Wrapper WETH9",
+    (
+      await deployments.get(
+        `${poolConfig.WrappedNativeTokenSymbol}${TESTNET_TOKEN_PREFIX}`
+      )
+    ).address
+  );
+
   console.log(
     "[Deployment][WARNING] Remember to setup the above testnet addresses at the ReservesConfig field inside the market configuration file and reuse testnet tokens"
   );


### PR DESCRIPTION
Deployment of reward tokens is conditional and based on whether `isIncentivesEnabled` is true and whether there are reward tokens configured. In absence of earlier conditions, there will be no reward tokens to log on console. So this PR is improving logging logic.